### PR TITLE
Bump Joi version to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "feathers-errors": "2.5.0",
     "feathers-hooks-common": "^1.6.1",
-    "joi": "8.4.2",
+    "joi": "^10.6.0",
     "joi-errors-for-forms": "^0.2.2"
   },
   "devDependencies": {


### PR DESCRIPTION
# Description

Pretty much what it says on the tin. The motivation for this is that the older version of Joi doesn't support the complete ISO 8601 spec (specifically timezone extensions), which is fixed in the 10.x.x versions.