### PR TITLE
Bump feathers-hooks-common version

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
 const Joi = require('joi');
 const errors = require('feathers-errors');
 //const utils = require('feathers-hooks-utils');
-const utils = require('feathers-hooks-common/lib/utils');
+const utils = require('feathers-hooks-common/lib/services');
 const joiErrorsForForms = require('joi-errors-for-forms');
 
 function validator(joiSchema, joiOptions, translator, ifTest) {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/eddyystop/feathers-hooks-validate-joi#readme",
   "dependencies": {
     "feathers-errors": "2.5.0",
-    "feathers-hooks-common": "^1.6.1",
+    "feathers-hooks-common": "^3.6.1",
     "joi": "^10.6.0",
     "joi-errors-for-forms": "^0.2.2"
   },


### PR DESCRIPTION
# Description

Another version bump. The motivation here is that ^1.6.1 version of feathers-hooks-common has a git dependency that goes away in later versions.